### PR TITLE
Fix wrong wordpress directory's property name in Wordpress\\Wordpress

### DIFF
--- a/Wordpress/Wordpress.php
+++ b/Wordpress/Wordpress.php
@@ -37,7 +37,7 @@ class Wordpress
     /**
      * @var string
      */
-    protected $wordpressDirectory;
+    protected $directory;
 
     /**
      * Constructor


### PR DESCRIPTION
Fix property name, added in commit #ab37a0da3f4dd19298ac257f494f6a01dfa16bff
