### PR TITLE
Make the entity manager configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('table_prefix')->end()
                 ->scalarNode('wordpress_directory')->end()
+                ->scalarNode('entity_manager')->end()
             ->end()
         ;
 

--- a/DependencyInjection/EkinoWordpressExtension.php
+++ b/DependencyInjection/EkinoWordpressExtension.php
@@ -12,6 +12,7 @@ namespace Ekino\WordpressBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
 
@@ -46,6 +47,10 @@ class EkinoWordpressExtension extends Extension
         if (isset($config['wordpress_directory'])) {
             $this->loadWordpressDirectory($container, $config['wordpress_directory']);
         }
+
+        if (isset($config['entity_manager'])) {
+            $this->loadEntityManager($container, $config['entity_manager']);
+        }
     }
 
     /**
@@ -78,6 +83,23 @@ class EkinoWordpressExtension extends Extension
         $serviceDefinition->addArgument($directory);
 
         $container->setDefinition($identifier, $serviceDefinition);
+    }
+
+    protected function loadEntityManager(ContainerBuilder $container, $em)
+    {
+        $reference = new Reference(sprintf('doctrine.orm.%s_entity_manager', $em));
+
+        $container->getDefinition('ekino.wordpress.manager.comment')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.comment_meta')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.link')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.option')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.post')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.post_meta')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.term')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.term_relationships')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.term_taxonomy')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.user')->replaceArgument(0, $reference);
+        $container->getDefinition('ekino.wordpress.manager.user_meta')->replaceArgument(0, $reference);
     }
 
     /**


### PR DESCRIPTION
In my application, I need to separate the "wordpress" entities from other entities. To do that, I use many entity managers like documented here : http://symfony.com/doc/current/cookbook/doctrine/multiple_entity_managers.html

With this PR, I can configure the entity manager that is injected into the managers and avoid this kind of error:

> MappingException: The class 'Ekino\WordpressBundle\Entity\User' was not found in the chain configured namespaces App\AppBundle\Entity

I'm not sure if this is the best way to handle this problem, but it is clean and works fine.

Exemple of configuration:

``` yaml
# app/config/config.yml

doctrine:
    dbal:
        default_connection:   default
        connections:
            default:
                driver:   %database_driver%
                host:     %database_host%
                port:     %database_port%
                dbname:   %database_name%
                user:     %database_user%
                password: %database_password%
                charset:  UTF8
    orm:
        default_entity_manager:   default
        entity_managers:
            default:
                connection:       default
                mappings:
                    AppBundle: ~
            wordpress:
                connection:       default
                mappings:
                    EkinoWordpressBundle: ~

ekino_wordpress:
    table_prefix: wp_
    entity_manager: wordpress
```
