### PR TITLE
Rolled back some changes, added Relationships

### DIFF
--- a/Entity/Post.php
+++ b/Entity/Post.php
@@ -108,9 +108,9 @@ class Post implements WordpressEntityInterface, WordpressContentInterface
     protected $contentFiltered;
 
     /**
-     * @var Post
+     * @var integer
      */
-    protected $parent;
+    protected $parent = 0;
 
     /**
      * @var string
@@ -431,11 +431,11 @@ class Post implements WordpressEntityInterface, WordpressContentInterface
     }
 
     /**
-     * @param Post $parent
+     * @param integer $parent
      *
      * @return Post
      */
-    public function setParent(Post $parent)
+    public function setParent($parent)
     {
         $this->parent = $parent;
 
@@ -443,7 +443,7 @@ class Post implements WordpressEntityInterface, WordpressContentInterface
     }
 
     /**
-     * @return Post
+     * @return integer
      */
     public function getParent()
     {

--- a/Entity/TermTaxonomy.php
+++ b/Entity/TermTaxonomy.php
@@ -9,6 +9,7 @@
  */
 
 namespace Ekino\WordpressBundle\Entity;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Class TermTaxonomy
@@ -25,7 +26,7 @@ class TermTaxonomy implements WordpressEntityInterface
     protected $id;
 
     /**
-     * @var integer
+     * @var Term
      */
     protected $term;
 
@@ -45,10 +46,22 @@ class TermTaxonomy implements WordpressEntityInterface
     protected $parent;
 
     /**
+     * @var ArrayCollection
+     */
+    protected $relationships;
+
+    /**
      * @var integer
      */
     protected $count;
 
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->relationships = new ArrayCollection();
+    }
 
     /**
      * @return int
@@ -99,11 +112,11 @@ class TermTaxonomy implements WordpressEntityInterface
     }
 
     /**
-     * @param TermTaxonomy $parent
+     * @param integer $parent
      *
      * @return TermTaxonomy
      */
-    public function setParent(TermTaxonomy $parent)
+    public function setParent($parent)
     {
         $this->parent = $parent;
 
@@ -111,7 +124,7 @@ class TermTaxonomy implements WordpressEntityInterface
     }
 
     /**
-     * @return TermTaxonomy
+     * @return integer
      */
     public function getParent()
     {
@@ -157,4 +170,41 @@ class TermTaxonomy implements WordpressEntityInterface
     {
         return $this->term;
     }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getRelationships()
+    {
+        return $this->relationships;
+    }
+
+    /**
+     * @param TermRelationships $relationship
+     *
+     * @return Term
+     */
+    public function addRelationship(TermRelationships $relationship)
+    {
+        if (!$this->relationships->contains($relationship)) {
+            $this->relationships[] = $relationship;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param TermRelationships $relationship
+     *
+     * @return Term
+     */
+    public function removeRelationship(TermRelationships $relationship)
+    {
+        if ($this->relationships->contains($relationship)) {
+            $this->relationships->remove($relationship);
+        }
+
+        return $this;
+    }
+
 }

--- a/Resources/config/doctrine/Post.orm.xml
+++ b/Resources/config/doctrine/Post.orm.xml
@@ -29,13 +29,10 @@
         <field name="type" nullable="false"  type="string" length="20" column="post_type" />
         <field name="mimeType" nullable="false"  type="string" length="100" column="post_mime_type" />
         <field name="commentCount" nullable="false"  type="bigint" length="20" column="comment_count" />
+        <field name="parent" column="post_parent" nullable="false" type="integer" length="11" />
 
         <many-to-one field="author" target-entity="Ekino\WordpressBundle\Entity\User">
             <join-column name="post_author" referenced-column-name="ID" />
-        </many-to-one>
-
-        <many-to-one field="parent" target-entity="Ekino\WordpressBundle\Entity\Post">
-            <join-column name="post_parent" referenced-column-name="ID" />
         </many-to-one>
 
         <one-to-many field="metas" target-entity="Ekino\WordpressBundle\Entity\PostMeta" mapped-by="post" />

--- a/Resources/config/doctrine/TermRelationships.orm.xml
+++ b/Resources/config/doctrine/TermRelationships.orm.xml
@@ -10,7 +10,7 @@
 
         <field name="termOrder" type="integer" length="11" column="term_order" />
 
-        <many-to-one field="taxonomy" target-entity="Ekino\WordpressBundle\Entity\TermTaxonomy">
+        <many-to-one field="taxonomy" target-entity="Ekino\WordpressBundle\Entity\TermTaxonomy" inversed-by="relationships">
             <join-column name="term_taxonomy_id" referenced-column-name="term_taxonomy_id" />
         </many-to-one>
 

--- a/Resources/config/doctrine/TermTaxonomy.orm.xml
+++ b/Resources/config/doctrine/TermTaxonomy.orm.xml
@@ -12,14 +12,14 @@
         <field name="taxonomy" nullable="false" type="string" length="32" column="taxonomy" />
         <field name="description" nullable="false" type="text" column="description" />
         <field name="count" nullable="false" type="integer" length="20" column="count" />
+        <field name="parent" nullable="false" type="integer" length="20" column="parent" />
 
         <many-to-one field="term" target-entity="Ekino\WordpressBundle\Entity\Term" inversed-by="taxonomies">
             <join-column name="term_id" referenced-column-name="term_id" />
         </many-to-one>
 
-        <many-to-one field="parent" target-entity="Ekino\WordpressBundle\Entity\TermTaxonomy">
-            <join-column name="parent" referenced-column-name="term_taxonomy_id" />
-        </many-to-one>
+        <one-to-many target-entity="Ekino\WordpressBundle\Entity\TermRelationships" mapped-by="taxonomy"
+                     field="relationships" />
 
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
We need to roll back some changes I introduced. Some of the relations wordpress has cannot be mapped directly in doctrine. So using integer fields instead was totally correct before. 
