### PR TITLE
Fix WordPress login hook

### DIFF
--- a/Event/Hook/UserHookListener.php
+++ b/Event/Hook/UserHookListener.php
@@ -78,10 +78,11 @@ class UserHookListener
         $user = $this->userManager->find($wpUser->data->ID);
         $user->setWordpressRoles($wpUser->roles);
 
-        $token = new UsernamePasswordToken($user, $user->getPass(), 'secured_area', $user->getRoles());
+        $firewall = 'secured_area';
+        $token = new UsernamePasswordToken($user, $user->getPass(), $firewall, $user->getRoles());
         $this->securityContext->setToken($token);
 
-        $this->session->set('token', $token);
+        $this->session->set('_security_' . $firewall, serialize($token));
     }
 
     /**


### PR DESCRIPTION
This fixes the WordPress login hook. Previously, after login into WordPress, accessing a protected area let to an error message stating "Full authentication required". A simple refresh would suffice, because after that the session was correctly initialized. This patch eliminates the need to refresh.

Reference: http://symfony.com/doc/2.4/cookbook/testing/simulating_authentication.html
