### PR TITLE
Fixed stateful response

### DIFF
--- a/Listener/WordpressRequestListener.php
+++ b/Listener/WordpressRequestListener.php
@@ -57,6 +57,10 @@ class WordpressRequestListener
      */
     protected function checkAuthentication(Request $request)
     {
+        if (!$request->hasPreviousSession()) {
+            return;
+        }
+
         $session = $request->getSession();
 
         if ($session->has('token')) {

--- a/Tests/Listener/WordpressRequestListenerTest.php
+++ b/Tests/Listener/WordpressRequestListenerTest.php
@@ -75,6 +75,7 @@ class WordpressRequestListenerTest extends \PHPUnit_Framework_TestCase
 
         // Set up a request mock to give to GetResponseEvent class below
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request->expects($this->once())->method('hasPreviousSession')->will($this->returnValue(true));
         $request->expects($this->any())->method('getSession')->will($this->returnValue($this->getSession()));
 
         $getResponseEvent = new GetResponseEvent(


### PR DESCRIPTION
When no session available, it used to force creation of a new one even when not needed :panda_face: 