### PR TITLE
Loop to ensure the same configuration is applied on every entity manager

### DIFF
--- a/DependencyInjection/EkinoWordpressExtension.php
+++ b/DependencyInjection/EkinoWordpressExtension.php
@@ -148,17 +148,9 @@ class EkinoWordpressExtension extends Extension
     {
         $reference = new Reference(sprintf('doctrine.orm.%s_entity_manager', $em));
 
-        $container->findDefinition('ekino.wordpress.manager.comment')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.comment_meta')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.link')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.option')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.post')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.post_meta')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.term')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.term_relationships')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.term_taxonomy')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.user')->replaceArgument(0, $reference);
-        $container->findDefinition('ekino.wordpress.manager.user_meta')->replaceArgument(0, $reference);
+        foreach (static::$entities as $entityName) {
+            $container->findDefinition(sprintf('ekino.wordpress.manager.%s', $entityName))->replaceArgument(0, $reference);
+        }
     }
 
     /**


### PR DESCRIPTION
Makes the method `loadEntityManager` consistent with `loadManagers` and `loadEntities`.