### PR TITLE
Forced indexes name to use native ones

### DIFF
--- a/Resources/config/doctrine/Comment.orm.xml
+++ b/Resources/config/doctrine/Comment.orm.xml
@@ -3,8 +3,11 @@
     <entity name="Ekino\WordpressBundle\Entity\Comment" table="comments">
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="comment_approved,comment_date_gmt"/>
-            <index columns="comment_date_gmt"/>
+            <index columns="comment_post_ID" name="comment_post_ID" />
+            <index columns="comment_approved,comment_date_gmt" name="comment_approved_date_gmt" />
+            <index columns="comment_date_gmt" name="comment_date_gmt" />
+            <index columns="comment_parent" name="comment_parent" />
+            <index columns="comment_author_email" name="comment_author_email" />
         </indexes>
 
         <id name="id" type="bigint" column="comment_ID">

--- a/Resources/config/doctrine/CommentMeta.orm.xml
+++ b/Resources/config/doctrine/CommentMeta.orm.xml
@@ -7,7 +7,8 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="meta_key"/>
+            <index columns="meta_key" name="meta_key" />
+            <index columns="comment_id" name="comment_id" />
         </indexes>
 
         <id name="id" type="bigint" column="meta_id">

--- a/Resources/config/doctrine/Link.orm.xml
+++ b/Resources/config/doctrine/Link.orm.xml
@@ -7,7 +7,7 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="link_visible"/>
+            <index columns="link_visible" name="link_visible" />
         </indexes>
 
         <id name="id" type="bigint" column="link_id">

--- a/Resources/config/doctrine/Option.orm.xml
+++ b/Resources/config/doctrine/Option.orm.xml
@@ -5,6 +5,10 @@
             repository-class="Ekino\WordpressBundle\Repository\OptionRepository"
             change-tracking-policy="DEFERRED_IMPLICIT">
 
+        <unique-constraints>
+            <unique-constraint columns="option_name" name="option_name" />
+        </unique-constraints>
+
         <id name="id" type="bigint" column="option_id">
             <generator strategy="AUTO"/>
             <options>

--- a/Resources/config/doctrine/Post.orm.xml
+++ b/Resources/config/doctrine/Post.orm.xml
@@ -7,9 +7,10 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="post_name"/>
-            <index columns="post_type,post_status,post_date,ID"/>
-            <index columns="post_status,post_date"/>
+            <index columns="post_name" name="post_name" />
+            <index columns="post_type,post_status,post_date,ID" name="type_status_date" />
+            <index columns="post_parent" name="post_parent" />
+            <index columns="post_author" name="post_author" />
         </indexes>
 
         <id name="id" type="bigint" column="ID">

--- a/Resources/config/doctrine/PostMeta.orm.xml
+++ b/Resources/config/doctrine/PostMeta.orm.xml
@@ -7,7 +7,8 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="meta_key"/>
+            <index columns="meta_key" name="meta_key" />
+            <index columns="post_id" name="post_id" />
         </indexes>
 
         <id name="id" type="bigint" column="meta_id">

--- a/Resources/config/doctrine/Term.orm.xml
+++ b/Resources/config/doctrine/Term.orm.xml
@@ -7,7 +7,8 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="name"/>
+            <index columns="name" name="name" />
+            <index columns="slug" name="slug" />
         </indexes>
 
         <id name="id" type="bigint" column="term_id">

--- a/Resources/config/doctrine/TermRelationships.orm.xml
+++ b/Resources/config/doctrine/TermRelationships.orm.xml
@@ -5,6 +5,10 @@
             repository-class="Ekino\WordpressBundle\Repository\TermRelationshipsRepository"
             change-tracking-policy="DEFERRED_IMPLICIT">
 
+        <indexes>
+            <index columns="term_taxonomy_id" name="term_taxonomy_id" />
+        </indexes>
+
         <id name="post" association-key="true" />
         <id name="taxonomy" association-key="true" />
 

--- a/Resources/config/doctrine/TermTaxonomy.orm.xml
+++ b/Resources/config/doctrine/TermTaxonomy.orm.xml
@@ -7,10 +7,10 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="taxonomy"/>
+            <index columns="taxonomy" name="taxonomy" />
         </indexes>
         <unique-constraints>
-            <unique-constraint columns="term_id,taxonomy"/>
+            <unique-constraint columns="term_id,taxonomy" name="term_id_taxonomy" />
         </unique-constraints>
 
         <id name="id" type="bigint" column="term_taxonomy_id">

--- a/Resources/config/doctrine/User.orm.xml
+++ b/Resources/config/doctrine/User.orm.xml
@@ -7,8 +7,8 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="user_login"/>
-            <index columns="user_nicename"/>
+            <index columns="user_login" name="user_login_key" />
+            <index columns="user_nicename" name="user_nicename" />
         </indexes>
 
         <id name="id" type="bigint" column="ID">

--- a/Resources/config/doctrine/UserMeta.orm.xml
+++ b/Resources/config/doctrine/UserMeta.orm.xml
@@ -7,7 +7,8 @@
 
         <!-- Mapped super classes won't support indexes -->
         <indexes>
-            <index columns="meta_key"/>
+            <index columns="meta_key" name="meta_key" />
+            <index columns="user_id" name="user_id" />
         </indexes>
 
         <id name="id" type="integer" column="umeta_id">

--- a/Resources/config/doctrine/model/Option.orm.xml
+++ b/Resources/config/doctrine/model/Option.orm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Ekino\WordpressBundle\Model\Option">
-        <field name="name" type="string" length="64" column="option_name" unique="true">
+        <field name="name" type="string" length="64" column="option_name">
             <options>
                 <option name="default"/>
             </options>

--- a/Resources/config/doctrine/model/Term.orm.xml
+++ b/Resources/config/doctrine/model/Term.orm.xml
@@ -6,7 +6,7 @@
                 <option name="default"/>
             </options>
         </field>
-        <field name="slug" type="string" length="200" column="slug" unique="true">
+        <field name="slug" type="string" length="200" column="slug">
             <options>
                 <option name="default"/>
             </options>


### PR DESCRIPTION
This PR will use Wordpress index original names to avoid useless CREATE/DROP INDEX statements