### PR TITLE
Switched to hautelook/phpass

### DIFF
--- a/Manager/PostManager.php
+++ b/Manager/PostManager.php
@@ -13,6 +13,7 @@ namespace Ekino\WordpressBundle\Manager;
 use Doctrine\ORM\EntityManager;
 use Ekino\WordpressBundle\Entity\Post;
 use Ekino\WordpressBundle\Repository\PostRepository;
+use Hautelook\Phpass\PasswordHash;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -91,7 +92,7 @@ class PostManager extends BaseManager
             return true;
         }
 
-        $wpHasher = new \PasswordHash(8, true);
+        $wpHasher = new PasswordHash(8, true);
 
         return !$wpHasher->CheckPassword($post->getPassword(), $hash);
     }

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,6 @@
             "email": "composieux@ekino.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "openwall/phpass",
-                "version": "0.3",
-                "dist": {
-                    "url": "http://www.openwall.com/phpass/phpass-0.3.tar.gz",
-                    "type": "tar"
-                },
-                "autoload": {
-                    "classmap": ["PasswordHash.php"]
-                }
-            }
-        }
-    ],
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.2",
@@ -34,7 +18,7 @@
         "symfony/monolog-bundle": ">=2.2",
         "doctrine/doctrine-bundle": ">=1.0",
         "doctrine/orm": ">=2.2",
-        "openwall/phpass": "0.3"
+        "hautelook/phpass": "0.3"
     },
     "suggest": {
         "twig/twig": ""


### PR DESCRIPTION
`"repositories"` block in a nested `composer.json` does not work as expected, the repos do not get imported. We should either use a Packagist-supported version of phpass, or add a note on adding the repository into end-user's `composer.json` file.
This switches to Hautelook's version, as it's way less tedious to go this way.