### PR TITLE
Added parameter to `wp_get_permalink` to return absolute url

### DIFF
--- a/Tests/Twig/Extension/PostExtensionTest.php
+++ b/Tests/Twig/Extension/PostExtensionTest.php
@@ -101,4 +101,40 @@ class PostExtensionTest extends \PHPUnit_Framework_TestCase
         $result = $this->postExtension->getPermalink(12);
         $this->assertEquals(date('/Y/m/d').'/12-sample-post', $result);
     }
+
+    public function testGetAbsolutePermalink()
+    {
+        $post = $this->getMock('Ekino\WordpressBundle\Entity\Post');
+        $permalinkOption = $this->getMock('Ekino\WordpressBundle\Entity\Option');
+        $homeOption = $this->getMock('Ekino\WordpressBundle\Entity\Option');
+
+        $post->expects($this->once())
+            ->method('getDate')
+            ->will($this->returnValue(new \DateTime()));
+        $post->expects($this->once())
+            ->method('getId')
+            ->will($this->returnValue('12'));
+        $post->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue('sample-post'));
+
+        $permalinkOption->expects($this->once())
+            ->method('getValue')
+            ->will($this->returnValue('/%year%/%monthnum%/%day%/%post_id%-%postname%'));
+        $homeOption->expects($this->once())
+            ->method('getValue')
+            ->will($this->returnValue('http://localhost/blog/'));
+        $this->postManager->expects($this->once())
+            ->method('find')
+            ->will($this->returnValue($post));
+        $this->optionExtension->expects($this->at(0))
+            ->method('getOption')
+            ->will($this->returnValue($permalinkOption));
+        $this->optionExtension->expects($this->at(1))
+            ->method('getOption')
+            ->will($this->returnValue($homeOption));
+
+        $result = $this->postExtension->getPermalink(12, true);
+        $this->assertEquals('http://localhost/blog' . date('/Y/m/d') . '/12-sample-post', $result);
+    }
 }

--- a/Twig/Extension/PostExtension.php
+++ b/Twig/Extension/PostExtension.php
@@ -71,12 +71,13 @@ class PostExtension extends \Twig_Extension
 
     /**
      * @param int|Post $postId
+     * @param bool $isAbsolute
      *
      * @return string
      *
      * @throws \UnexpectedValueException
      */
-    public function getPermalink($postId)
+    public function getPermalink($postId, $isAbsolute = false)
     {
         $post = $postId instanceof Post ? $postId : $this->postManager->find($postId);
 
@@ -86,7 +87,14 @@ class PostExtension extends \Twig_Extension
 
         $permalinkStructure = $this->optionExtension->getOption('permalink_structure', '')->getValue();
 
-        return $this->replacePostArguments($permalinkStructure, $post);
+        $relativeUrl = $this->replacePostArguments($permalinkStructure, $post);
+        if($isAbsolute) {
+            $home = $this->optionExtension->getOption('home');
+
+            return rtrim($home->getValue(), '/') . '/' . ltrim($relativeUrl, '/');
+        }
+
+        return $relativeUrl;
     }
 
     /**

--- a/Twig/Extension/PostExtension.php
+++ b/Twig/Extension/PostExtension.php
@@ -70,8 +70,8 @@ class PostExtension extends \Twig_Extension
     }
 
     /**
-     * @param int|Post $postId
-     * @param bool $isAbsolute
+     * @param int|Post $postId     A Wordpress post identifier
+     * @param bool     $isAbsolute Determines if you want to retrieve an absolute URL
      *
      * @return string
      *
@@ -88,7 +88,8 @@ class PostExtension extends \Twig_Extension
         $permalinkStructure = $this->optionExtension->getOption('permalink_structure', '')->getValue();
 
         $relativeUrl = $this->replacePostArguments($permalinkStructure, $post);
-        if($isAbsolute) {
+
+        if ($isAbsolute) {
             $home = $this->optionExtension->getOption('home');
 
             return rtrim($home->getValue(), '/') . '/' . ltrim($relativeUrl, '/');


### PR DESCRIPTION
Hi 

The patch adds param `isAbsolute` to `wp_get_permalink` twig function. It is `false` by default - so there should not be any BC breaks.

In my case - I have blog installed in `blog` subdir and path relative to hostname (`/2015/07/08/12-sample-post`) is not correct.

Hope this makes sense.

Thanks