### PR TITLE
Add option to disable WordPress kernel request listener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('load_twig_extension')->defaultFalse()->end()
                 ->booleanNode('cookie_hash')->defaultNull()->end()
                 ->scalarNode('i18n_cookie_name')->defaultFalse()->end()
+                ->booleanNode('enable_wordpress_listener')->defaultTrue()->end()
 
                 ->arrayNode('globals')
                     ->prototype('scalar')->end()

--- a/DependencyInjection/EkinoWordpressExtension.php
+++ b/DependencyInjection/EkinoWordpressExtension.php
@@ -83,6 +83,10 @@ class EkinoWordpressExtension extends Extension
             $loader->load('i18n.xml');
         }
 
+        if ($config['enable_wordpress_listener']) {
+            $loader->load('listener.xml');
+        }
+
         if (isset($config['globals'])) {
             $this->loadWordpressGlobals($container, $config['globals']);
         }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ ekino_wordpress:
     table_prefix: "wp_" # If you have a specific Wordpress table prefix
     wordpress_directory: "/my/wordpress/directory" # If you have a specific Wordpress directory structure
     load_twig_extension: true # If you want to enable native WordPress functions (ie : get_option() => wp_get_option())
+    enable_wordpress_listener: false # If you want to disable the WordPress request listener
     security:
         firewall_name: "secured_area" # This is the firewall default name
         login_url: "/wp-login.php" # Absolute URL to the wordpress login page

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <!-- Listeners -->
+
+        <service id="ekino.wordpress.listener.wordpress_request" class="Ekino\WordpressBundle\Listener\WordpressRequestListener" public="true">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+
+            <argument type="service" id="ekino.wordpress.wordpress" />
+            <argument type="service" id="security.token_storage" />
+        </service>
+
+    </services>
+</container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,15 +21,6 @@
             <argument />
         </service>
 
-        <!-- Listeners -->
-
-        <service id="ekino.wordpress.listener.wordpress_request" class="Ekino\WordpressBundle\Listener\WordpressRequestListener" public="true">
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
-
-            <argument type="service" id="ekino.wordpress.wordpress" />
-            <argument type="service" id="security.token_storage" />
-        </service>
-
         <!-- Security -->
 
         <service id="ekino.wordpress.security.entry_point" class="Ekino\WordpressBundle\Security\WordpressEntryPoint" public="true">


### PR DESCRIPTION
In my case, I want to use the bundle only to have a Doctrine database mapping.

So I want to disable the kernel request listener. This PR add an option to do this.