### PR TITLE
Fix Symfony 3.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^5.4|^7.0",
         "symfony/framework-bundle": "^2.6|^3.0",
         "symfony/security-bundle": "^2.6|^3.0",
-        "symfony/monolog-bundle": "^2.2",
+        "symfony/monolog-bundle": "^2.2|^3.0",
         "doctrine/doctrine-bundle": "^1.0",
         "doctrine/orm": "^2.2",
         "hautelook/phpass": "0.3"


### PR DESCRIPTION
Fix Symfony 3.2 compatibility

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - ekino/wordpress-bundle dev-master requires symfony/monolog-bundle ^2.2 -> satisfiable by symfony/monolog-bundle[2.11.0, 2.11.1, 2.11.3, 2.12.0, 2.2.x-dev, 2.3.x-dev, 2.8.1, 2.x-dev, v2.10.0, v2.11.2, v2.2.0, v2.2.0-BETA1, v2.2.0-BETA2, v2.2.0-RC2, v2.3.0, v2.3.0-BETA2, v2.3.0-RC1, v2.4.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.6.1, v2.7.0, v2.7.1, v2.8.0, v2.8.2, v2.9.0] but these conflict with your requirements or minimum-stability.
    - ekino/wordpress-bundle dev-master requires symfony/monolog-bundle ^2.2 -> satisfiable by symfony/monolog-bundle[2.11.0, 2.11.1, 2.11.3, 2.12.0, 2.2.x-dev, 2.3.x-dev, 2.8.1, 2.x-dev, v2.10.0, v2.11.2, v2.2.0, v2.2.0-BETA1, v2.2.0-BETA2, v2.2.0-RC2, v2.3.0, v2.3.0-BETA2, v2.3.0-RC1, v2.4.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.6.1, v2.7.0, v2.7.1, v2.8.0, v2.8.2, v2.9.0] but these conflict with your requirements or minimum-stability.
    - Installation request for ekino/wordpress-bundle dev-master@dev -> satisfiable by ekino/wordpress-bundle[dev-master].
```