### PR TITLE
fix TermTaxonomy::parent mapping to get wp_get_term_link

### DIFF
--- a/Resources/config/doctrine/TermTaxonomy.orm.xml
+++ b/Resources/config/doctrine/TermTaxonomy.orm.xml
@@ -26,8 +26,8 @@
             <join-column name="term_id" referenced-column-name="term_id" nullable="false" />
         </many-to-one>
 
-        <many-to-one field="parent" target-entity="Ekino\WordpressBundle\Entity\Term">
-            <join-column name="parent" referenced-column-name="term_id" nullable="false" />
+        <many-to-one field="parent" target-entity="Ekino\WordpressBundle\Entity\TermTaxonomy">
+            <join-column name="parent" referenced-column-name="term_taxonomy_id" nullable="false" />
         </many-to-one>
     </entity>
 </doctrine-mapping>

--- a/Twig/Extension/TermTaxonomyExtension.php
+++ b/Twig/Extension/TermTaxonomyExtension.php
@@ -57,7 +57,7 @@ class TermTaxonomyExtension extends \Twig_Extension
         $output = [$termTaxonomy->getTerm()->getSlug()];
 
         while ($parent = $termTaxonomy->getParent()) {
-            $output[] = $parent->getSlug();
+            $output[] = $parent->getTerm()->getSlug();
             $termTaxonomy = $parent;
         }
 


### PR DESCRIPTION
the `wp_get_term_link()` twig method kept failing because `TermTaxonomy::parent` was hydrated with a `Term` instead a `TermTaxonomy`.