### PR TITLE
Define 'ekino_wordpress.model_manager_name' automatically

### DIFF
--- a/DependencyInjection/EkinoWordpressExtension.php
+++ b/DependencyInjection/EkinoWordpressExtension.php
@@ -138,6 +138,8 @@ class EkinoWordpressExtension extends Extension
      */
     protected function loadEntityManager(ContainerBuilder $container, $em)
     {
+        $container->setParameter('ekino_wordpress.model_manager_name', $em);
+
         $reference = new Reference(sprintf('doctrine.orm.%s_entity_manager', $em));
 
         foreach (static::$entities as $entityName) {


### PR DESCRIPTION
I you want to use a custom entity manager by setting the `entity_manager` in your app configuration, it doesn't work.

I find it is because the `ekino_wordpress.model_manager_name` parameter which is used in the [`RegisterMappingsPass`](https://github.com/ekino/EkinoWordpressBundle/blob/master/DependencyInjection/Compiler/RegisterMappingsPass.php#L98) is not defined.

In case the use have change the default entity manager, doesn't this parameter should be automatically register ? 
Even if it is automatically setup, developers can override it.