### PR TITLE
Fix phppass dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/monolog-bundle": "^2.2|^3.0|^4.0",
         "doctrine/doctrine-bundle": "^1.0",
         "doctrine/orm": "^2.2",
-        "hautelook/phpass": "0.3"
+        "bordoni/phpass": "0.3"
     },
     "suggest": {
         "twig/twig": ""


### PR DESCRIPTION
Hello,

Just tried to install your project and i see that dependency `hautelook/phppass` was deleted from Github on 2021-09-09

Here a PR that use a fork of hautelook/phppasss => [https://github.com/bordoni/phpass](https://github.com/bordoni/phpass)

Thanks